### PR TITLE
feat: 진료 일정 관리 기능 추가 (달력 및 할 일 목록)

### DIFF
--- a/src/main/java/com/example/be/controller/ScheduleController.java
+++ b/src/main/java/com/example/be/controller/ScheduleController.java
@@ -1,0 +1,75 @@
+package com.example.be.controller;
+
+import com.example.be.dto.request.CreateScheduleEventRequestDto;
+import com.example.be.dto.request.CreateTodoItemRequestDto;
+import com.example.be.dto.response.ScheduleEventDto;
+import com.example.be.dto.response.TodoItemDto;
+import com.example.be.service.ScheduleService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/schedule")
+@RequiredArgsConstructor
+public class ScheduleController {
+
+    private final ScheduleService scheduleService;
+
+    // === 달력 일정 (ScheduleEvent) API ===
+
+    @GetMapping("/events")
+    public ResponseEntity<List<ScheduleEventDto>> getScheduleEvents(
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+        List<ScheduleEventDto> events = scheduleService.getScheduleEvents(startDate, endDate);
+        return ResponseEntity.ok(events);
+    }
+
+    @PostMapping("/events")
+    public ResponseEntity<ScheduleEventDto> createScheduleEvent(@Valid @RequestBody CreateScheduleEventRequestDto requestBody) {
+        ScheduleEventDto createdEvent = scheduleService.createScheduleEvent(requestBody);
+        return ResponseEntity.status(HttpStatus.CREATED).body(createdEvent);
+    }
+
+    @PutMapping("/events/{eventId}")
+    public ResponseEntity<ScheduleEventDto> updateScheduleEvent(
+            @PathVariable Integer eventId,
+            @Valid @RequestBody CreateScheduleEventRequestDto requestBody) {
+        ScheduleEventDto updatedEvent = scheduleService.updateScheduleEvent(eventId, requestBody);
+        return ResponseEntity.ok(updatedEvent);
+    }
+
+    @DeleteMapping("/events/{eventId}")
+    public ResponseEntity<Map<String, String>> deleteScheduleEvent(@PathVariable Integer eventId) {
+        scheduleService.deleteScheduleEvent(eventId);
+        return ResponseEntity.ok(Map.of("message", "일정이 성공적으로 삭제되었습니다."));
+    }
+
+    // === 할 일 목록 (TodoItem) API ===
+
+    @GetMapping("/todos")
+    public ResponseEntity<List<TodoItemDto>> getTodoItems(@RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+        List<TodoItemDto> items = scheduleService.getTodoItems(date);
+        return ResponseEntity.ok(items);
+    }
+
+    @PostMapping("/todos")
+    public ResponseEntity<TodoItemDto> createTodoItem(@Valid @RequestBody CreateTodoItemRequestDto requestBody) {
+        TodoItemDto createdItem = scheduleService.createTodoItem(requestBody);
+        return ResponseEntity.status(HttpStatus.CREATED).body(createdItem);
+    }
+
+    @PatchMapping("/todos/{todoId}/toggle")
+    public ResponseEntity<TodoItemDto> toggleTodoItemCompletion(@PathVariable Integer todoId) {
+        TodoItemDto updatedItem = scheduleService.toggleTodoItem(todoId);
+        return ResponseEntity.ok(updatedItem);
+    }
+}

--- a/src/main/java/com/example/be/dto/request/CreateScheduleEventRequestDto.java
+++ b/src/main/java/com/example/be/dto/request/CreateScheduleEventRequestDto.java
@@ -1,0 +1,24 @@
+package com.example.be.dto.request;
+
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import java.time.LocalDateTime;
+
+@Getter
+public class CreateScheduleEventRequestDto {
+
+    @NotBlank(message = "일정 제목을 입력해주세요.")
+    private String title;
+
+    @NotNull(message = "시작 시간을 입력해주세요.")
+    @FutureOrPresent(message = "시작 시간은 현재 또는 미래여야 합니다.")
+    private LocalDateTime startTime;
+
+    @NotNull(message = "종료 시간을 입력해주세요.")
+    @FutureOrPresent(message = "종료 시간은 현재 또는 미래여야 합니다.")
+    private LocalDateTime endTime;
+
+    private String memo;
+}

--- a/src/main/java/com/example/be/dto/request/CreateTodoItemRequestDto.java
+++ b/src/main/java/com/example/be/dto/request/CreateTodoItemRequestDto.java
@@ -1,0 +1,16 @@
+package com.example.be.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import java.time.LocalDate;
+
+@Getter
+public class CreateTodoItemRequestDto {
+
+    @NotBlank(message = "할 일 내용을 입력해주세요.")
+    private String content;
+
+    @NotNull(message = "날짜를 지정해주세요.")
+    private LocalDate targetDate;
+}

--- a/src/main/java/com/example/be/dto/response/ScheduleEventDto.java
+++ b/src/main/java/com/example/be/dto/response/ScheduleEventDto.java
@@ -1,0 +1,28 @@
+package com.example.be.dto.response;
+
+import com.example.be.entity.ScheduleEvent;
+import lombok.Builder;
+import lombok.Getter;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ScheduleEventDto {
+    private Integer eventId;
+    private Integer memberId;
+    private String title;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+    private String memo;
+
+    public static ScheduleEventDto fromEntity(ScheduleEvent entity) {
+        return ScheduleEventDto.builder()
+                .eventId(entity.getEventId())
+                .memberId(entity.getMember().getId())
+                .title(entity.getTitle())
+                .startTime(entity.getStartTime())
+                .endTime(entity.getEndTime())
+                .memo(entity.getMemo())
+                .build();
+    }
+}

--- a/src/main/java/com/example/be/dto/response/TodoItemDto.java
+++ b/src/main/java/com/example/be/dto/response/TodoItemDto.java
@@ -1,0 +1,26 @@
+package com.example.be.dto.response;
+
+import com.example.be.entity.TodoItem;
+import lombok.Builder;
+import lombok.Getter;
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class TodoItemDto {
+    private Integer todoId;
+    private Integer memberId;
+    private String content;
+    private LocalDate targetDate;
+    private boolean isCompleted;
+
+    public static TodoItemDto fromEntity(TodoItem entity) {
+        return TodoItemDto.builder()
+                .todoId(entity.getTodoId())
+                .memberId(entity.getMember().getId())
+                .content(entity.getContent())
+                .targetDate(entity.getTargetDate())
+                .isCompleted(entity.isCompleted())
+                .build();
+    }
+}

--- a/src/main/java/com/example/be/entity/ScheduleEvent.java
+++ b/src/main/java/com/example/be/entity/ScheduleEvent.java
@@ -1,0 +1,47 @@
+package com.example.be.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "schedule_event")
+public class ScheduleEvent {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "event_id")
+    private Integer eventId;
+
+    // 어떤 사용자의 일정인지 연결합니다.
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "title", nullable = false)
+    private String title; // 일정 제목 (예: "환자 CT 판독")
+
+    @Column(name = "start_time", nullable = false)
+    private LocalDateTime startTime; // 일정 시작 시간
+
+    @Column(name = "end_time", nullable = false)
+    private LocalDateTime endTime; // 일정 종료 시간 (시작 시간 + 소요 시간으로 계산)
+
+    @Column(name = "memo", columnDefinition = "TEXT")
+    private String memo; // 메모
+
+    // 수정을 위한 편의 메소드
+    public void update(String title, LocalDateTime startTime, LocalDateTime endTime, String memo) {
+        this.title = title;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.memo = memo;
+    }
+}

--- a/src/main/java/com/example/be/entity/TodoItem.java
+++ b/src/main/java/com/example/be/entity/TodoItem.java
@@ -1,0 +1,47 @@
+package com.example.be.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "todo_item")
+public class TodoItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "todo_id")
+    private Integer todoId;
+
+    // 어떤 사용자의 할 일인지 연결합니다.
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "content", nullable = false)
+    private String content; // 할 일 내용
+
+    @Column(name = "target_date", nullable = false)
+    private LocalDate targetDate; // 이 할 일이 속한 날짜
+
+    @Column(name = "is_completed", nullable = false)
+    @ColumnDefault("false") // 데이터베이스에 기본값으로 false를 지정
+    private boolean isCompleted; // 완료 여부
+
+    // 완료 상태를 변경하는 편의 메소드
+    public void complete() {
+        this.isCompleted = true;
+    }
+
+    public void incomplete() {
+        this.isCompleted = false;
+    }
+}

--- a/src/main/java/com/example/be/repository/ScheduleEventRepository.java
+++ b/src/main/java/com/example/be/repository/ScheduleEventRepository.java
@@ -1,0 +1,18 @@
+package com.example.be.repository;
+
+import com.example.be.entity.Member;
+import com.example.be.entity.ScheduleEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface ScheduleEventRepository extends JpaRepository<ScheduleEvent, Integer> {
+
+    // 특정 사용자의 특정 기간 동안의 모든 일정을 조회
+    List<ScheduleEvent> findAllByMemberAndStartTimeBetween(Member member, LocalDateTime start, LocalDateTime end);
+
+    // 특정 사용자의 특정 일정을 조회 (소유권 확인용)
+    Optional<ScheduleEvent> findByEventIdAndMember(Integer eventId, Member member);
+}

--- a/src/main/java/com/example/be/repository/TodoItemRepository.java
+++ b/src/main/java/com/example/be/repository/TodoItemRepository.java
@@ -1,0 +1,18 @@
+package com.example.be.repository;
+
+import com.example.be.entity.Member;
+import com.example.be.entity.TodoItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface TodoItemRepository extends JpaRepository<TodoItem, Integer> {
+
+    // 특정 사용자의 특정 날짜의 모든 할 일을 조회
+    List<TodoItem> findAllByMemberAndTargetDate(Member member, LocalDate date);
+
+    // 특정 사용자의 특정 할 일을 조회 (소유권 확인용)
+    Optional<TodoItem> findByTodoIdAndMember(Integer todoId, Member member);
+}

--- a/src/main/java/com/example/be/service/ScheduleService.java
+++ b/src/main/java/com/example/be/service/ScheduleService.java
@@ -1,0 +1,127 @@
+package com.example.be.service;
+
+import com.example.be.dto.request.CreateScheduleEventRequestDto;
+import com.example.be.dto.request.CreateTodoItemRequestDto;
+import com.example.be.dto.response.ScheduleEventDto;
+import com.example.be.dto.response.TodoItemDto;
+import com.example.be.entity.Member;
+import com.example.be.entity.ScheduleEvent;
+import com.example.be.entity.TodoItem;
+import com.example.be.repository.MemberRepository;
+import com.example.be.repository.ScheduleEventRepository;
+import com.example.be.repository.TodoItemRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.TemporalAdjusters;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ScheduleService {
+
+    private final MemberRepository memberRepository;
+    private final ScheduleEventRepository scheduleEventRepository;
+    private final TodoItemRepository todoItemRepository;
+
+    // === 달력 일정 (ScheduleEvent) 관련 서비스 ===
+
+    @Transactional(readOnly = true)
+    public List<ScheduleEventDto> getScheduleEvents(LocalDate startDate, LocalDate endDate) {
+        Member member = getCurrentMember();
+
+        if (startDate == null || endDate == null) {
+            LocalDate today = LocalDate.now();
+            startDate = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+            endDate = today.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY));
+        }
+
+        LocalDateTime startDateTime = startDate.atStartOfDay();
+        LocalDateTime endDateTime = endDate.plusDays(1).atStartOfDay();
+
+        List<ScheduleEvent> events = scheduleEventRepository.findAllByMemberAndStartTimeBetween(member, startDateTime, endDateTime);
+
+        return events.stream()
+                .map(ScheduleEventDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    public ScheduleEventDto createScheduleEvent(CreateScheduleEventRequestDto dto) {
+        Member member = getCurrentMember();
+        ScheduleEvent newEvent = ScheduleEvent.builder()
+                .member(member)
+                .title(dto.getTitle())
+                .startTime(dto.getStartTime())
+                .endTime(dto.getEndTime())
+                .memo(dto.getMemo())
+                .build();
+        ScheduleEvent savedEvent = scheduleEventRepository.save(newEvent);
+        return ScheduleEventDto.fromEntity(savedEvent);
+    }
+
+    public ScheduleEventDto updateScheduleEvent(Integer eventId, CreateScheduleEventRequestDto dto) {
+        Member member = getCurrentMember();
+        ScheduleEvent event = scheduleEventRepository.findByEventIdAndMember(eventId, member)
+                .orElseThrow(() -> new SecurityException("수정 권한이 없거나 존재하지 않는 일정입니다."));
+
+        event.update(dto.getTitle(), dto.getStartTime(), dto.getEndTime(), dto.getMemo());
+        return ScheduleEventDto.fromEntity(event);
+    }
+
+    public void deleteScheduleEvent(Integer eventId) {
+        Member member = getCurrentMember();
+        ScheduleEvent event = scheduleEventRepository.findByEventIdAndMember(eventId, member)
+                .orElseThrow(() -> new SecurityException("삭제 권한이 없거나 존재하지 않는 일정입니다."));
+        scheduleEventRepository.delete(event);
+    }
+
+    // === 할 일 목록 (TodoItem) 관련 서비스 ===
+
+    @Transactional(readOnly = true)
+    public List<TodoItemDto> getTodoItems(LocalDate date) {
+        Member member = getCurrentMember();
+        List<TodoItem> items = todoItemRepository.findAllByMemberAndTargetDate(member, date);
+        return items.stream()
+                .map(TodoItemDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    public TodoItemDto createTodoItem(CreateTodoItemRequestDto dto) {
+        Member member = getCurrentMember();
+        TodoItem newItem = TodoItem.builder()
+                .member(member)
+                .content(dto.getContent())
+                .targetDate(dto.getTargetDate())
+                .isCompleted(false)
+                .build();
+        TodoItem savedItem = todoItemRepository.save(newItem);
+        return TodoItemDto.fromEntity(savedItem);
+    }
+
+    public TodoItemDto toggleTodoItem(Integer todoId) {
+        Member member = getCurrentMember();
+        TodoItem item = todoItemRepository.findByTodoIdAndMember(todoId, member)
+                .orElseThrow(() -> new SecurityException("권한이 없거나 존재하지 않는 할 일입니다."));
+
+        if (item.isCompleted()) {
+            item.incomplete();
+        } else {
+            item.complete();
+        }
+        return TodoItemDto.fromEntity(item);
+    }
+
+    // 현재 로그인한 사용자 정보를 가져오는 헬퍼 메소드
+    private Member getCurrentMember() {
+        String email = SecurityContextHolder.getContext().getAuthentication().getName();
+        return memberRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("로그인한 사용자 정보를 찾을 수 없습니다."));
+    }
+}


### PR DESCRIPTION
사용자가 개인의 진료 및 업무 스케줄을 효율적으로 관리할 수 있도록 달력 기반의 일정 관리와 날짜별 할 일 목록(To-Do List) 기능을 새롭게 추가했습니다.

Pull Request(PR)를 작성할 때 다른 팀원들이 변경 사항을 쉽고 명확하게 이해할 수 있도록 작성하는 것이 중요해요. 아래 템플릿을 그대로 복사해서 사용하시거나 필요에 맞게 수정해서 사용해 보세요. 😊

PR 제목 (Title)
feat: 진료 일정 관리 기능 추가 (달력 및 할 일 목록)

<br>

PR 본문 (Body)
설명 (Description)
사용자가 개인의 진료 및 업무 스케줄을 효율적으로 관리할 수 있도록 달력 기반의 일정 관리와 날짜별 할 일 목록(To-Do List) 기능을 새롭게 추가했습니다.

주요 기능 (Key Features)
📅 달력 일정 관리

주(Week) 단위로 일정을 조회할 수 있습니다. (기본값: 현재 주)

특정 기간을 지정하여 일정을 조회할 수 있습니다.

새로운 일정을 **생성(C), 수정(U), 삭제(D)**할 수 있습니다.

✅ 할 일 목록 (To-Do List) 관리

특정 날짜의 할 일 목록을 조회할 수 있습니다.

새로운 할 일을 **추가(C)**하고, **완료/미완료 상태를 변경(U)**할 수 있습니다.

변경 사항 (Changes)
Entity 추가

ScheduleEvent.java: 시간 기반의 달력 일정을 저장하는 엔티티

TodoItem.java: 날짜 기반의 할 일 목록을 저장하는 엔티티

Repository 추가

ScheduleEventRepository.java

TodoItemRepository.java

DTO 추가

request/CreateScheduleEventRequestDto.java

request/CreateTodoItemRequestDto.java

response/ScheduleEventDto.java

response/TodoItemDto.java

Service 및 Controller 추가

ScheduleService.java: 일정 및 할 일 관련 비즈니스 로직 처리

ScheduleController.java: 관련 API 엔드포인트 제공

GET /api/v1/schedule/events

POST /api/v1/schedule/events

PUT /api/v1/schedule/events/{eventId}

DELETE /api/v1/schedule/events/{eventId}

GET /api/v1/schedule/todos

POST /api/v1/schedule/todos

PATCH /api/v1/schedule/todos/{todoId}/toggle

